### PR TITLE
Fix dependabot.yml: expand YAML anchors (not supported by Dependabot)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,14 +1,15 @@
 version: 2
-
-x-defaults: &defaults
-  directory: "/"
-  schedule:
-    interval: "weekly"
-  cooldown:
-    default-days: 7
-
 updates:
-  - <<: *defaults
-    package-ecosystem: "gradle"
-  - <<: *defaults
-    package-ecosystem: "github-actions"
+  - package-ecosystem: "gradle"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
- GitHub's Dependabot does not support YAML anchors/aliases; expand the shared config inline for each ecosystem entry