### PR TITLE
Modernise app & test code

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,7 +2,7 @@ plugins {
     id("java")
     id("groovy")
     id("application")
-    kotlin("jvm") version "2.3.21"
+    alias(libs.plugins.kotlin.jvm)
 }
 
 repositories {
@@ -10,16 +10,16 @@ repositories {
 }
 
 dependencies {
-    implementation("io.airlift:airline:0.9")
-    implementation("org.eclipse.jgit:org.eclipse.jgit:7.6.0.202603022253-r")
-    implementation("org.jetbrains.kotlin:kotlin-stdlib")
-    implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
+    implementation(libs.airline)
+    implementation(libs.jgit)
+    implementation(libs.kotlin.stdlib)
+    implementation(libs.kotlin.stdlib.jdk8)
 
-    runtimeOnly("org.slf4j:slf4j-simple:2.0.18")
+    runtimeOnly(libs.slf4j.simple)
 
     testImplementation(gradleTestKit())
-    testImplementation("org.spockframework:spock-core:2.4-groovy-3.0")
-    testImplementation("junit:junit:4.13.2")
+    testImplementation(libs.spock.core)
+    testImplementation(libs.junit)
 }
 
 java {
@@ -30,8 +30,6 @@ application {
     mainClass.set("org.gradle.builds.Main")
 }
 
-tasks {
-    "test"(Test::class) {
-        maxParallelForks = 2
-    }
+tasks.named<Test>("test") {
+    maxParallelForks = 2
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,6 +12,7 @@ repositories {
 dependencies {
     implementation(libs.picocli)
     implementation(libs.jgit)
+    implementation(libs.jspecify)
     implementation(libs.kotlin.stdlib)
 
     runtimeOnly(libs.slf4j.simple)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ repositories {
 }
 
 dependencies {
-    implementation(libs.airline)
+    implementation(libs.picocli)
     implementation(libs.jgit)
     implementation(libs.kotlin.stdlib)
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,7 +13,6 @@ dependencies {
     implementation(libs.airline)
     implementation(libs.jgit)
     implementation(libs.kotlin.stdlib)
-    implementation(libs.kotlin.stdlib.jdk8)
 
     runtimeOnly(libs.slf4j.simple)
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,16 +1,16 @@
 [versions]
-airline = "0.9"
 jgit = "7.6.0.202603022253-r"
 junit = "4.13.2"
 kotlin = "2.3.21"
+picocli = "4.7.7"
 slf4j = "2.0.18"
 spock = "2.4-groovy-3.0"
 
 [libraries]
-airline = { module = "io.airlift:airline", version.ref = "airline" }
 jgit = { module = "org.eclipse.jgit:org.eclipse.jgit", version.ref = "jgit" }
 junit = { module = "junit:junit", version.ref = "junit" }
 kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib", version.ref = "kotlin" }
+picocli = { module = "info.picocli:picocli", version.ref = "picocli" }
 slf4j-simple = { module = "org.slf4j:slf4j-simple", version.ref = "slf4j" }
 spock-core = { module = "org.spockframework:spock-core", version.ref = "spock" }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,7 @@
 [versions]
 jgit = "7.6.0.202603022253-r"
 junit = "4.13.2"
+jspecify = "1.0.0"
 kotlin = "2.3.21"
 picocli = "4.7.7"
 slf4j = "2.0.18"
@@ -9,6 +10,7 @@ spock = "2.4-groovy-3.0"
 [libraries]
 jgit = { module = "org.eclipse.jgit:org.eclipse.jgit", version.ref = "jgit" }
 junit = { module = "junit:junit", version.ref = "junit" }
+jspecify = { module = "org.jspecify:jspecify", version.ref = "jspecify" }
 kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib", version.ref = "kotlin" }
 picocli = { module = "info.picocli:picocli", version.ref = "picocli" }
 slf4j-simple = { module = "org.slf4j:slf4j-simple", version.ref = "slf4j" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,7 +11,6 @@ airline = { module = "io.airlift:airline", version.ref = "airline" }
 jgit = { module = "org.eclipse.jgit:org.eclipse.jgit", version.ref = "jgit" }
 junit = { module = "junit:junit", version.ref = "junit" }
 kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib", version.ref = "kotlin" }
-kotlin-stdlib-jdk8 = { module = "org.jetbrains.kotlin:kotlin-stdlib-jdk8", version.ref = "kotlin" }
 slf4j-simple = { module = "org.slf4j:slf4j-simple", version.ref = "slf4j" }
 spock-core = { module = "org.spockframework:spock-core", version.ref = "spock" }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,19 @@
+[versions]
+airline = "0.9"
+jgit = "7.6.0.202603022253-r"
+junit = "4.13.2"
+kotlin = "2.3.21"
+slf4j = "2.0.18"
+spock = "2.4-groovy-3.0"
+
+[libraries]
+airline = { module = "io.airlift:airline", version.ref = "airline" }
+jgit = { module = "org.eclipse.jgit:org.eclipse.jgit", version.ref = "jgit" }
+junit = { module = "junit:junit", version.ref = "junit" }
+kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib", version.ref = "kotlin" }
+kotlin-stdlib-jdk8 = { module = "org.jetbrains.kotlin:kotlin-stdlib-jdk8", version.ref = "kotlin" }
+slf4j-simple = { module = "org.slf4j:slf4j-simple", version.ref = "slf4j" }
+spock-core = { module = "org.spockframework:spock-core", version.ref = "spock" }
+
+[plugins]
+kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }

--- a/src/main/java/org/gradle/builds/Main.java
+++ b/src/main/java/org/gradle/builds/Main.java
@@ -1,82 +1,70 @@
 package org.gradle.builds;
 
-import io.airlift.airline.*;
 import org.gradle.builds.assemblers.*;
 import org.gradle.builds.generators.*;
 import org.gradle.builds.model.*;
+import picocli.CommandLine;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.HelpCommand;
+import picocli.CommandLine.Option;
 
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.Callable;
 
-public class Main {
+@Command(
+        name = "build-builder",
+        mixinStandardHelpOptions = true,
+        subcommands = {
+                Main.InitJavaBuild.class,
+                Main.InitKotlinBuild.class,
+                Main.InitCppBuild.class,
+                Main.InitAndroidBuild.class,
+                Main.InitSwiftBuild.class,
+                HelpCommand.class
+        }
+)
+public class Main implements Runnable {
     private static final GraphAssembler graphAssembler = new GraphAssembler();
 
     public static void main(String[] args) {
-        try {
-            new Main().run(args);
-        } catch (SettingsNotAvailableException e) {
-            // Reported
-            System.exit(1);
-        } catch (Throwable throwable) {
-            throwable.printStackTrace();
-            System.exit(2);
-        }
-
-        System.exit(0);
+        int exitCode = new CommandLine(new Main()).execute(args);
+        System.exit(exitCode);
     }
 
-    public void run(String[] args) throws Exception {
-        Cli.CliBuilder<Callable<Void>> cliBuilder = new Cli.CliBuilder<>("build-builder");
-        cliBuilder.withCommand(InitJavaBuild.class);
-        cliBuilder.withCommand(InitKotlinBuild.class);
-        cliBuilder.withCommand(InitCppBuild.class);
-        cliBuilder.withCommand(InitAndroidBuild.class);
-        cliBuilder.withCommand(InitSwiftBuild.class);
-        cliBuilder.withCommand(Help.class);
-        cliBuilder.withDefaultCommand(Help.class);
-        Cli<Callable<Void>> cli = cliBuilder.build();
-
-        try {
-            cli.parse(args).call();
-        } catch (ParseException | CommandLineValidationException e) {
-            System.out.println(e.getMessage());
-            System.out.println();
-            Help.help(cli.getMetadata(), Collections.emptyList());
-            throw new SettingsNotAvailableException();
-        }
+    @Override
+    public void run() {
+        CommandLine.usage(this, System.out);
     }
 
-    private static class CommandLineValidationException extends RuntimeException {
-        public CommandLineValidationException(String message) {
-            super(message);
-        }
-    }
-
-    private static class SettingsNotAvailableException extends RuntimeException {
+    // Programmatic entry point used by integration tests; propagates execution
+    // exceptions instead of swallowing them as picocli's default execute() would.
+    public void run(String... args) throws Exception {
+        new CommandLine(this)
+                .setExecutionExceptionHandler((ex, cmd, parseResult) -> { throw ex; })
+                .execute(args);
     }
 
     public static abstract class InitBuild implements Callable<Void> {
-        @Option(name = "--source-files", description = "The number of source files to generate for each project (default: 3)")
+        @Option(names = "--source-files", description = "The number of source files to generate for each project (default: 3)")
         int sourceFiles = 3;
 
-        @Option(name = "--dir", description = "The directory to generate into (default: current directory)")
+        @Option(names = "--dir", description = "The directory to generate into (default: current directory)")
         String rootDir = ".";
 
-        @Option(name = "--projects", description = "The number of projects to include in the build (default: 1)")
+        @Option(names = "--projects", description = "The number of projects to include in the build (default: 1)")
         int projects = 1;
 
-        @Option(name = "--included-builds", description = "The number of included builds to generate (default: 0)")
+        @Option(names = "--included-builds", description = "The number of included builds to generate (default: 0)")
         int builds = 0;
 
-        @Option(name = "--source-dep-builds", description = "The number of source dependency builds to generate (default: 0)")
+        @Option(names = "--source-dep-builds", description = "The number of source dependency builds to generate (default: 0)")
         int sourceDeps = 0;
 
-        @Option(name = "--buildsrc", description = "Generate a buildSrc build? (default: false)")
+        @Option(names = "--buildsrc", description = "Generate a buildSrc build? (default: false)")
         boolean buildSrc;
 
         @Override
@@ -219,13 +207,13 @@ public class Main {
     }
 
     public static abstract class InitBinaryDependencyAwareBuild extends InitBuild {
-        @Option(name = "--http-repo", description = "Generate an HTTP repository (default: false)")
+        @Option(names = "--http-repo", description = "Generate an HTTP repository (default: false)")
         boolean httpRepo = false;
 
-        @Option(name = "--http-repo-libraries", description = "Number of libraries to include in the HTTP repository (default: 3)")
+        @Option(names = "--http-repo-libraries", description = "Number of libraries to include in the HTTP repository (default: 3)")
         int httpRepoLibraries = 3;
 
-        @Option(name = "--http-repo-versions", description = "Number of versions of each library to include in the HTTP repository (default: 1)")
+        @Option(names = "--http-repo-versions", description = "Number of versions of each library to include in the HTTP repository (default: 1)")
         int httpRepoVersions = 1;
 
         @Override
@@ -254,7 +242,7 @@ public class Main {
         }
     }
 
-    @Command(name = "java", description = "Generates a Java build with source files")
+    @Command(name = "java", description = "Generates a Java build with source files", mixinStandardHelpOptions = true)
     public static class InitJavaBuild extends InitBinaryDependencyAwareBuild {
         @Override
         protected String getType() {
@@ -272,7 +260,7 @@ public class Main {
         }
     }
 
-    @Command(name = "kotlin", description = "Generates a Kotlin build with source files")
+    @Command(name = "kotlin", description = "Generates a Kotlin build with source files", mixinStandardHelpOptions = true)
     public static class InitKotlinBuild extends InitBinaryDependencyAwareBuild {
         @Override
         protected String getType() {
@@ -290,15 +278,15 @@ public class Main {
         }
     }
 
-    @Command(name = "cpp", description = "Generates a C++ build with source files")
+    @Command(name = "cpp", description = "Generates a C++ build with source files", mixinStandardHelpOptions = true)
     public static class InitCppBuild extends InitBinaryDependencyAwareBuild {
-        @Option(name = "--header-files", description = "The number of header files to generate for each project (default: 3)")
+        @Option(names = "--header-files", description = "The number of header files to generate for each project (default: 3)")
         int headers = 3;
 
-        @Option(name = "--macro-include", description = "Specifies how headers files should reference other header files (values: none, simple, complex. default: none)")
+        @Option(names = "--macro-include", description = "Specifies how headers files should reference other header files (values: none, simple, complex. default: none)")
         MacroIncludes macroIncludes = MacroIncludes.none;
 
-        @Option(name = "--boost", description = "Include reference to boost libraries (default: false)")
+        @Option(names = "--boost", description = "Include reference to boost libraries (default: false)")
         boolean boost;
 
         @Override
@@ -330,9 +318,9 @@ public class Main {
         }
     }
 
-    @Command(name = "swift", description = "Generates a Swift build with source files")
+    @Command(name = "swift", description = "Generates a Swift build with source files", mixinStandardHelpOptions = true)
     public static class InitSwiftBuild extends InitBuild {
-        @Option(name = "--swift-pm", description = "Use the Swift package manager source layout (default: false)")
+        @Option(names = "--swift-pm", description = "Use the Swift package manager source layout (default: false)")
         boolean swiftPm = false;
 
         @Override
@@ -351,12 +339,12 @@ public class Main {
         }
     }
 
-    @Command(name = "android", description = "Generates an Android build with source files")
+    @Command(name = "android", description = "Generates an Android build with source files", mixinStandardHelpOptions = true)
     public static class InitAndroidBuild extends InitBinaryDependencyAwareBuild {
-        @Option(name = "--version", description = "Android plugin version (default: " + AndroidModelAssembler.defaultVersion + ")")
+        @Option(names = "--version", description = "Android plugin version (default: " + AndroidModelAssembler.defaultVersion + ")")
         String androidVersion = AndroidModelAssembler.defaultVersion;
 
-        @Option(name = "--java", description = "Include some Java libraries (default: false)")
+        @Option(names = "--java", description = "Include some Java libraries (default: false)")
         boolean includeJavaLibraries = false;
 
         @Override

--- a/src/main/java/org/gradle/builds/assemblers/LanguageSpecificProjectConfigurer.kt
+++ b/src/main/java/org/gradle/builds/assemblers/LanguageSpecificProjectConfigurer.kt
@@ -35,6 +35,6 @@ abstract class LanguageSpecificProjectConfigurer<A : Component, L : Component>(v
     }
 
     protected fun capitalize(s: String): String {
-        return s.capitalize()
+        return s.replaceFirstChar { it.uppercaseChar() }
     }
 }

--- a/src/main/java/org/gradle/builds/generators/GitRepoGenerator.java
+++ b/src/main/java/org/gradle/builds/generators/GitRepoGenerator.java
@@ -87,7 +87,12 @@ public class GitRepoGenerator implements Generator<BuildTree<ConfiguredBuild>> {
                 }
                 addCommand.call();
 
-                git.commit().setMessage("Initial version").call();
+                git.commit()
+                        .setAuthor("build-builder", "build-builder@gradle.com")
+                        .setCommitter("build-builder", "build-builder@gradle.com")
+                        .setSign(false)
+                        .setMessage("Initial version")
+                        .call();
                 git.tagDelete().setTags(repo.getVersion()).call();
                 git.tag().setName(repo.getVersion()).call();
             }

--- a/src/main/java/org/gradle/builds/model/DefaultBuildStructureBuilder.java
+++ b/src/main/java/org/gradle/builds/model/DefaultBuildStructureBuilder.java
@@ -3,7 +3,8 @@ package org.gradle.builds.model;
 import org.gradle.builds.assemblers.ComposableProjectInitializer;
 import org.gradle.builds.assemblers.Settings;
 
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
+
 import java.nio.file.Path;
 import java.util.LinkedHashSet;
 import java.util.Set;

--- a/src/main/kotlin/org/gradle/builds/assemblers/GradlePluginModelAssembler.kt
+++ b/src/main/kotlin/org/gradle/builds/assemblers/GradlePluginModelAssembler.kt
@@ -15,7 +15,7 @@ class GradlePluginModelAssembler : ComponentSpecificProjectConfigurer<GradlePlug
         val id = component.id!!
         val pos = id.lastIndexOf(".")
         val baseName = id.substring(pos + 1)
-        val impl = project.qualifiedNamespaceFor + '.' + baseName.capitalize() + "Plugin"
+        val impl = project.qualifiedNamespaceFor + '.' + baseName.replaceFirstChar { it.uppercaseChar() } + "Plugin"
         component.implClass = JavaClass(impl)
 
         val block = buildScript.block("gradlePlugin").block("plugins").block(baseName)

--- a/src/test/groovy/org/gradle/builds/AbstractIntegrationTest.groovy
+++ b/src/test/groovy/org/gradle/builds/AbstractIntegrationTest.groovy
@@ -1,42 +1,33 @@
 package org.gradle.builds
 
 import groovy.io.FileType
-import junit.framework.AssertionFailedError
+import org.opentest4j.AssertionFailedError
 import org.eclipse.jgit.api.Git
 import org.eclipse.jgit.storage.file.FileRepositoryBuilder
 import org.gradle.testkit.runner.GradleRunner
-import org.junit.Rule
-import org.junit.rules.TemporaryFolder
 import spock.lang.Specification
+import spock.lang.TempDir
 
 import java.util.function.Consumer
 import java.util.regex.Pattern
 
 abstract class AbstractIntegrationTest extends Specification {
-    @Rule
-    TemporaryFolder tmpDir = new TemporaryFolder(getRootTempDir())
-    static File rootTmpDir
+    private static final File SHARED_TESTKIT_DIR = new File("build/tmp/tests/testkit").canonicalFile.tap { mkdirs() }
+
+    @TempDir
+    File tmpDir
     File projectDir
     File userHomeDir
     String gradleVersion = "5.0"
     BuildLayout build
 
-    static File getRootTempDir() {
-        if (rootTmpDir == null) {
-            def file = new File("build/tmp/tests").canonicalFile
-            file.mkdirs()
-            rootTmpDir = file
-        }
-        return rootTmpDir
-    }
-
     def setup() {
-        projectDir = tmpDir.newFolder("generated-root-dir")
+        projectDir = new File(tmpDir, "generated-root-dir").tap { mkdirs() }
         build = new BuildLayout(projectDir)
     }
 
     void useIsolatedUserHome() {
-        userHomeDir = tmpDir.newFolder("user-home")
+        userHomeDir = new File(tmpDir, "user-home").tap { mkdirs() }
     }
 
     File file(String path) {
@@ -201,7 +192,7 @@ abstract class AbstractIntegrationTest extends Specification {
         void buildSucceeds(String... tasks) {
             def gradleRunner = GradleRunner.create()
             gradleRunner.withGradleVersion(gradleVersion)
-            gradleRunner.withTestKitDir(userHomeDir ?: new File(rootTempDir, "testkit"))
+            gradleRunner.withTestKitDir(userHomeDir ?: SHARED_TESTKIT_DIR)
             gradleRunner.withProjectDir(rootDir)
             gradleRunner.withArguments(["-S"] + (tasks as List))
             gradleRunner.forwardOutput()


### PR DESCRIPTION
Dependency and code hygiene that stands on its own, ahead of the Gradle wrapper bump.

- Migrate to a Gradle version catalog so dependency coordinates have one home.
- Drop `kotlin-stdlib-jdk8` (folded into `kotlin-stdlib` since Kotlin 1.8) and replace `String.capitalize()` (deprecated in Kotlin 1.5) — both emit warnings on Kotlin 2.x.
- Replace `io.airlift:airline` (unmaintained since 2014) with picocli. Adds a `Main.run(String...)` overload so the existing programmatic entry point used by integration tests keeps working.
- Adopt JSpecify `@Nullable`; the previous `javax.annotation.Nullable` came in transitively via airline and is no longer on the classpath.
- Move integration tests off the remaining JUnit 4 usages: `@Rule TemporaryFolder` → Spock `@TempDir`, `junit.framework.AssertionFailedError` → `org.opentest4j.AssertionFailedError`. Spock 2.x already provides both natively.
- `GitRepoGenerator`: set explicit author/committer on the initial commit. JGit 7 (already on `main`) silently produces no commit when `user.name`/`user.email` aren't configured, where JGit 4 was permissive.